### PR TITLE
Potential fix for code scanning alert no. 4: DOM text reinterpreted as HTML

### DIFF
--- a/static/oscar/js/oscar/ui.js
+++ b/static/oscar/js/oscar/ui.js
@@ -22,6 +22,35 @@ var oscar = (function(o, $) {
         }
     };
 
+    // Utility helpers.
+    o.utils = o.utils || {};
+    /**
+     * Basic URL sanitization to avoid navigating to dangerous schemes such as
+     * "javascript:" or "data:". Returns an empty string if the URL is not allowed.
+     */
+    o.utils.sanitiseUrl = function(url) {
+        if (!url) {
+            return '';
+        }
+        var trimmed = $.trim(url);
+        // Disallow dangerous schemes
+        var lower = trimmed.toLowerCase();
+        if (lower.indexOf('javascript:') === 0 ||
+            lower.indexOf('data:') === 0 ||
+            lower.indexOf('vbscript:') === 0) {
+            return '';
+        }
+        // Optionally, only allow relative URLs or http/https
+        if (lower.indexOf('http://') === 0 || lower.indexOf('https://') === 0) {
+            return trimmed;
+        }
+        if (trimmed.charAt(0) === '/' || trimmed.charAt(0) === '?' || trimmed.charAt(0) === '#') {
+            return trimmed;
+        }
+        // Anything else is rejected
+        return '';
+    };
+
     o.search = {
         init: function() {
             o.search.initSortWidget();
@@ -36,7 +65,13 @@ var oscar = (function(o, $) {
         initFacetWidgets: function() {
             // Bind events to facet checkboxes
             $('.facet_checkbox').on('change', function() {
-                window.location.href = $(this).nextAll('.facet_url').val();
+                var rawUrl = $(this).nextAll('.facet_url').val();
+                var safeUrl = (o.utils && typeof o.utils.sanitiseUrl === 'function')
+                    ? o.utils.sanitiseUrl(rawUrl)
+                    : rawUrl;
+                if (safeUrl) {
+                    window.location.href = safeUrl;
+                }
             });
         }
     };


### PR DESCRIPTION
Potential fix for [https://github.com/Rupreht/dev.e365/security/code-scanning/4](https://github.com/Rupreht/dev.e365/security/code-scanning/4)

In general, when using a value read from the DOM to change `window.location`, you should treat it as untrusted input and validate or normalize it before use. At minimum, ensure the URL uses an expected scheme (e.g., `http:` or `https:` or a same-origin path), and reject or ignore values starting with `javascript:`, `data:`, or other dangerous schemes. This prevents an attacker from injecting script execution via a crafted URL stored in the DOM.

For this specific code, the minimal, behavior-preserving fix is to read the value from `.facet_url`, then pass it through a helper that only allows safe URLs, and only assign `window.location.href` if the URL passes the checks. We can add a small `o.utils` (or similar) helper within the same IIFE in `static/oscar/js/oscar/ui.js` that inspects the string and rejects any URL that does not start with `/`, `#`, or `http(s)://` (or that starts with `javascript:`, `data:`, etc.). The `initFacetWidgets` function will then call this helper instead of using the raw value. No new external libraries are strictly needed; the checks can be done with simple string methods and a basic `try/catch` around `new URL` if desired, but we can keep it straightforward using prefix checks.

Concretely:
- Modify the `initFacetWidgets` handler around line 38–40 to store `var rawUrl = $(this).nextAll('.facet_url').val();`, call `var safeUrl = o.utils && o.utils.sanitiseUrl ? o.utils.sanitiseUrl(rawUrl) : rawUrl;`, and only assign `window.location.href = safeUrl;` if `safeUrl` is non-empty.
- Add a small `o.utils` object with a `sanitiseUrl` function earlier in the same IIFE (e.g., after `o.messages` or before `o.search`), which:
  - Returns an empty string (or `null`) if the input is falsy.
  - Trims the string.
  - Rejects schemes like `javascript:`, `data:`, `vbscript:`.
  - Optionally allows only relative URLs (starting with `/` or `?`) or absolute `http:`/`https:` URLs.

This keeps the visible behavior (navigating to the facet’s URL) while preventing navigation to obviously unsafe schemes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
