### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/static/oscar/js/bootstrap4/bootstrap.js
+++ b/static/oscar/js/bootstrap4/bootstrap.js
@@ -1098,7 +1098,7 @@
         return;
       }
 
-      var target = $__default["default"](selector)[0];
+      var target = $__default["default"](document).find(selector)[0];
 
       if (!target || !$__default["default"](target).hasClass(CLASS_NAME_CAROUSEL)) {
         return;


### PR DESCRIPTION
Potential fix for [https://github.com/Rupreht/dev.e365/security/code-scanning/1](https://github.com/Rupreht/dev.e365/security/code-scanning/1)

To fix the problem, we need to ensure that the `selector` is sanitized before it is used in the jQuery selector. This can be achieved by using a method that only interprets the `selector` as a CSS selector and not as HTML. We can use `$.find` instead of `$` to ensure that the `selector` is treated safely.

- Replace the usage of `$` with `$.find` when using the `selector` variable.
- Ensure that the `selector` is properly sanitized and validated before it is used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
